### PR TITLE
Switch to 2020-12

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -3,11 +3,11 @@
 	<extension>
 		<groupId>org.eclipse.tycho.extras</groupId>
 		<artifactId>tycho-pomless</artifactId>
-		<version>1.7.0</version>
+		<version>2.1.0</version>
 	</extension>
 	<extension>
 		<groupId>org.palladiosimulator</groupId>
 		<artifactId>tycho-tp-refresh-maven-plugin</artifactId>
-		<version>0.2.5</version>
+		<version>0.2.6</version>
 	</extension>
 </extensions>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.palladiosimulator</groupId>
 		<artifactId>eclipse-parent-updatesite</artifactId>
-		<version>0.6.0</version>
+		<version>0.7.1</version>
 	</parent>
 	<groupId>org.palladiosimulator.editorstree</groupId>
 	<artifactId>parent</artifactId>	

--- a/releng/org.palladiosimulator.editorstree.targetplatform/tp.target
+++ b/releng/org.palladiosimulator.editorstree.targetplatform/tp.target
@@ -75,13 +75,9 @@
 <unit id="org.modelversioning.emfprofile.feature.feature.group" version="tbd"/>
 <repository location="https://updatesite.palladio-simulator.com/palladio-thirdparty-emfprofiles/nightly/"/>
 </location>
-<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="release" refresh="true">
-<unit id="tools.mdsd.ecoreworkflow.umlecoregenerator.feature.feature.group" version="tbd"/>
-<repository location="https://updatesite.mdsd.tools/ecore-workflow/releases/latest/"/>
-</location>
-<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="nightly" refresh="true">
-<unit id="tools.mdsd.ecoreworkflow.umlecoregenerator.feature.feature.group" version="tbd"/>
-<repository location="https://updatesite.mdsd.tools/ecore-workflow/nightly/"/>
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
+<unit id="tools.mdsd.ecoreworkflow.umlecoregenerator.feature.feature.group" version="0.0.0"/>
+<repository location="https://updatesite.mdsd.tools/ecore-workflow/releases/0.3.0/"/>
 </location>
 </locations>
 </target>


### PR DESCRIPTION
Fixes build errors because of recent changes of EcoreWorkflow (introduces dependency to 2020-12).